### PR TITLE
SWF-3869: Update PLF components versions to 5.0.x-SNAPSHOT

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -35,19 +35,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.gatein.sso</groupId>
+      <groupId>org.exoplatform.gatein.sso</groupId>
       <artifactId>sso-auth-callback</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.web.sso.integration-configs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.web.sso.agents-configs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.sso</groupId>
+      <groupId>org.exoplatform.gatein.sso</groupId>
       <artifactId>sso-packaging</artifactId>
       <type>zip</type>
     </dependency>
@@ -69,7 +69,7 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.gatein.sso</groupId>
+                  <groupId>org.exoplatform.gatein.sso</groupId>
                   <artifactId>sso-packaging</artifactId>
                   <type>zip</type>
                   <outputDirectory>${project.build.directory}/sso-packaging.zip</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -51,32 +51,32 @@
     <!-- Dependencies versions -->
     <!-- **************************************** -->
     <org.exoplatform.depmgt.version>13-SNAPSHOT</org.exoplatform.depmgt.version>
-    <org.gatein.sso.version>1.4.5.Final</org.gatein.sso.version>
-    <org.gatein.portal.version>4.5.x-PLF-SNAPSHOT</org.gatein.portal.version>
+    <org.exoplatform.gatein.sso.version>5.0.x-SNAPSHOT</org.exoplatform.gatein.sso.version>
+    <org.exoplatform.gatein.portal.version>5.0.x-SNAPSHOT</org.exoplatform.gatein.portal.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.gatein.sso</groupId>
+        <groupId>org.exoplatform.gatein.sso</groupId>
         <artifactId>sso-auth-callback</artifactId>
-        <version>${org.gatein.sso.version}</version>
+        <version>${org.exoplatform.gatein.sso.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.sso</groupId>
+        <groupId>org.exoplatform.gatein.sso</groupId>
         <artifactId>sso-packaging</artifactId>
-        <version>${org.gatein.sso.version}</version>
+        <version>${org.exoplatform.gatein.sso.version}</version>
         <type>zip</type>
       </dependency>
       <dependency>
-        <groupId>org.gatein.portal</groupId>
+        <groupId>org.exoplatform.gatein.portal</groupId>
         <artifactId>exo.portal.component.web.sso.integration-configs</artifactId>
-        <version>${org.gatein.portal.version}</version>
+        <version>${org.exoplatform.gatein.portal.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.portal</groupId>
+        <groupId>org.exoplatform.gatein.portal</groupId>
         <artifactId>exo.portal.component.web.sso.agents-configs</artifactId>
-        <version>${org.gatein.portal.version}</version>
+        <version>${org.exoplatform.gatein.portal.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* maven dependencies updated to depends on
 * PLF versions 5.0.x-SNAPSHOT
 * groupId org.exoplatform.gatein.* instead of org.gatein for
gatein-wci, gatein-pc and gatein-portal